### PR TITLE
Add unit tests for all modules

### DIFF
--- a/tests/test_commands_cmr.py
+++ b/tests/test_commands_cmr.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest import mock
+
+from bottle_bot.commands import cmr
+
+
+class CMRCommandTests(unittest.TestCase):
+    def test_run_creates_ticket_with_compressed_summary(self):
+        pr_info = {
+            'title': 'My Title',
+            'body': 'x' * 60,
+            'html_url': 'http://example.com/pr/1'
+        }
+        called = {}
+
+        def fake_compress(text):
+            called['compress_text'] = text
+            return 'short'
+
+        def fake_create_ticket(project_key, title, summary, pr_url):
+            called['project_key'] = project_key
+            called['title'] = title
+            called['summary'] = summary
+            called['pr_url'] = pr_url
+            return {'key': 'PROJ-1', 'url': 'url'}
+
+        with mock.patch.object(cmr.compressor, 'compress', fake_compress), \
+             mock.patch.object(cmr.jira_client, 'create_ticket', fake_create_ticket):
+            result = cmr.run(pr_info, ['PROJ'])
+
+        self.assertEqual(called['compress_text'], pr_info['body'])
+        self.assertEqual(called['project_key'], 'PROJ')
+        self.assertEqual(called['title'], 'My Title')
+        self.assertEqual(called['summary'], 'short')
+        self.assertEqual(called['pr_url'], 'http://example.com/pr/1')
+        self.assertEqual(result['key'], 'PROJ-1')
+
+    def test_run_without_project_key_raises(self):
+        with self.assertRaises(ValueError):
+            cmr.run({}, [])
+

--- a/tests/test_commands_help.py
+++ b/tests/test_commands_help.py
@@ -1,0 +1,10 @@
+import unittest
+
+from bottle_bot.commands import help
+
+
+class HelpCommandTests(unittest.TestCase):
+    def test_run_returns_help_text(self):
+        result = help.run({}, [])
+        self.assertIn('CMR', result)
+

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest import mock
+
+from bottle_bot.github import client
+
+
+class GitHubClientTests(unittest.TestCase):
+    def test_get_pr_returns_info(self):
+        pr = client.get_pr(5)
+        self.assertEqual(pr['number'], 5)
+        self.assertIn('html_url', pr)
+
+    def test_post_comment_prints(self):
+        with mock.patch('builtins.print') as mock_print:
+            client.post_comment(2, 'hi')
+            mock_print.assert_called_with('Would post comment to PR 2: hi')
+

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -1,0 +1,11 @@
+import unittest
+
+from bottle_bot.jira import client
+
+
+class JiraClientTests(unittest.TestCase):
+    def test_create_ticket(self):
+        ticket = client.create_ticket('PROJ', 'Title', 'Summary', 'url')
+        self.assertEqual(ticket['key'], 'PROJ-123')
+        self.assertIn('PROJ-123', ticket['url'])
+

--- a/tests/test_llm_compressor.py
+++ b/tests/test_llm_compressor.py
@@ -1,0 +1,10 @@
+import unittest
+
+from bottle_bot.llm import compressor
+
+
+class CompressorTests(unittest.TestCase):
+    def test_compress_truncates_to_50_chars(self):
+        text = 'a' * 60
+        self.assertEqual(compressor.compress(text), 'a' * 50)
+

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest import mock
+from io import BytesIO
+import json
+
+from bottle_bot import server
+
+
+class ServerTests(unittest.TestCase):
+    def make_handler(self, payload, event='issue_comment'):
+        data = json.dumps(payload).encode('utf-8')
+        handler = server.WebhookHandler.__new__(server.WebhookHandler)
+        handler.rfile = BytesIO(data)
+        handler.wfile = BytesIO()
+        handler.headers = {
+            'content-length': str(len(data)),
+            'X-GitHub-Event': event
+        }
+        handler.send_response = lambda code: setattr(handler, 'response_code', code)
+        handler.end_headers = lambda: None
+        return handler
+
+    def test_do_post_processes_comment(self):
+        payload = {
+            'comment': {'body': '@bottle help'},
+            'issue': {'number': 1, 'pull_request': {'url': 'x'}}
+        }
+        handler = self.make_handler(payload)
+        pr_info = {'title': 't'}
+        with mock.patch.object(server.gh_client, 'get_pr', return_value=pr_info) as gp, \
+             mock.patch.object(server, 'handle_comment', return_value='res') as hc, \
+             mock.patch.object(server.gh_client, 'post_comment') as pc:
+            server.WebhookHandler.do_POST(handler)
+        gp.assert_called_with(1)
+        hc.assert_called_with('@bottle help', pr_info)
+        pc.assert_called_with(1, 'res')
+        self.assertEqual(handler.response_code, 200)
+
+    def test_run_starts_server(self):
+        with mock.patch('bottle_bot.server.HTTPServer') as mock_server:
+            server.run(1234)
+            mock_server.assert_called_with(('', 1234), server.WebhookHandler)
+            mock_server.return_value.serve_forever.assert_called_once()
+


### PR DESCRIPTION
## Summary
- test CMR command interaction with Jira and compressor
- test help command output
- test GitHub client helpers
- test Jira client stub
- test LLM compressor
- test server WebhookHandler and run() logic

## Testing
- `python3 -m unittest discover -v`