### PR TITLE
Implement GitHub client

### DIFF
--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -5,13 +5,24 @@ from bottle_bot.github import client
 
 
 class GitHubClientTests(unittest.TestCase):
-    def test_get_pr_returns_info(self):
-        pr = client.get_pr(5)
+    def test_get_pr_calls_api(self):
+        fake_resp = mock.Mock()
+        fake_resp.json.return_value = {'number': 5}
+        fake_resp.raise_for_status = mock.Mock()
+        with mock.patch.object(client, 'REPO', 'own/repo'):
+            with mock.patch.object(client.session, 'get', return_value=fake_resp) as mget:
+                pr = client.get_pr(5)
+        mget.assert_called_with('https://api.github.com/repos/own/repo/pulls/5')
+        fake_resp.raise_for_status.assert_called_once()
         self.assertEqual(pr['number'], 5)
-        self.assertIn('html_url', pr)
 
-    def test_post_comment_prints(self):
-        with mock.patch('builtins.print') as mock_print:
-            client.post_comment(2, 'hi')
-            mock_print.assert_called_with('Would post comment to PR 2: hi')
+    def test_post_comment_calls_api(self):
+        fake_resp = mock.Mock()
+        fake_resp.raise_for_status = mock.Mock()
+        with mock.patch.object(client, 'REPO', 'own/repo'):
+            with mock.patch.object(client.session, 'post', return_value=fake_resp) as mpost:
+                client.post_comment(2, 'hi')
+        mpost.assert_called_with('https://api.github.com/repos/own/repo/issues/2/comments',
+                                 json={'body': 'hi'})
+        fake_resp.raise_for_status.assert_called_once()
 


### PR DESCRIPTION
## Summary
- connect to GitHub's REST API via requests instead of returning stub data
- update GitHub client tests for API calls

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*